### PR TITLE
Add Google Closure Compiler removal to version 2.4

### DIFF
--- a/content/pages/4_roadmap.md
+++ b/content/pages/4_roadmap.md
@@ -1,6 +1,6 @@
 Title: Roadmap
 Date: 2017-06-20
-Modified: 2017-11-10
+Modified: 2017-11-14
 Authors: Michael Kalbermatten, Rémi Bovard
 URL: roadmap
 Save_as: roadmap.html
@@ -9,7 +9,7 @@ Lang: en
 <br />
 Here under you will find the GeomapFish roadmap and the functionalities changelog.
 
-*Latest page update: **2017-11-10***
+*Latest page update: **2017-11-14***
 
 ## Version 2.4
 
@@ -30,7 +30,8 @@ Next coming version:
 7. App loading - performance improvements
 8. Object recentering & re-zooming improvements
 9. Dynamic layertree width resizing
-10. Autogenerate hyperlinks with query results 
+10. Autogenerate hyperlinks with query results
+11. Remove Google Closure Compiler dependency, use Webpack
 
 ## Version 2.3
 

--- a/content/pages/4_roadmap_de.md
+++ b/content/pages/4_roadmap_de.md
@@ -1,6 +1,6 @@
 Title: Roadmap
 Date: 2017-06-20
-Modified: 2017-11-10
+Modified: 2017-11-14
 Authors: Michael Kalbermatten, Rémi Bovard, Irene Vontobel
 URL: roadmap
 Save_as: roadmap.html
@@ -9,7 +9,7 @@ Lang: de
 <br />
 Hier unten finden Sie die Roadmap von GeoMapFish, aber auch die Links zu den Release Notes der verschiedenen Versionen.
 
-*Letztes Update der Seite: **10.11.2017***
+*Letztes Update der Seite: **14.11.2017***
 
 ## Version 2.4
 
@@ -33,6 +33,7 @@ Version in Planung:
 8. Objekte Recentering & Zooming Verbesserungen
 9. Dynamisch die Layertree Breite verändern
 10. Automatische Generation von Hyperlinks in den Query Ergebnisse
+11. Google Closure Compiler Abschaffung; Benützung von Webpack
 
 ## Version 2.3
 

--- a/content/pages/4_roadmap_fr.md
+++ b/content/pages/4_roadmap_fr.md
@@ -1,6 +1,6 @@
 Title: Roadmap
 Date: 2017-06-20
-Modified: 2017-11-10
+Modified: 2017-11-14
 Authors: Michael Kalbermatten, Rémi Bovard
 URL: roadmap
 Save_as: roadmap.html
@@ -9,7 +9,7 @@ Lang: fr
 <br />
 Ci-dessous vous trouvez la roadmap de GeoMapFish ainsi que les notes listant les nouvelles fonctionnalités de chaque version.
 
-*Dernière mise à jour de la page: **10.11.2017***
+*Dernière mise à jour de la page: **14.11.2017***
 
 ## Version 2.4
 
@@ -31,6 +31,7 @@ Future version:
 8. Recentrage et zoom sur les objets
 9. Modification dynamique de la largeur de l'arbre des couches
 10. Génération automatique d'hyperliens à partir des résultats d'interrogation
+11. Suppression de la dépendance à Google Closure Compiler, utilisation de Webpack
 
 ## Version 2.3
 


### PR DESCRIPTION
Asked by @gnerred.

Thanks @rbovard